### PR TITLE
Simplify callback query parameter handling

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -87,7 +87,7 @@ async def incoming_call_handler(request: Request):
             incoming_call_context = event.data["incomingCallContext"]
             guid = uuid.uuid4()
 
-            query_parameters = urlencode({"callerId": caller_id, "boo": "poop"})
+            query_parameters = urlencode({"callerId": caller_id})
             callback_uri = f"{CALLBACK_EVENTS_URI}/{guid}?{query_parameters}"
 
             parsed_url = urlparse(CALLBACK_EVENTS_URI)


### PR DESCRIPTION
## Summary
- only include `callerId` when building callback query parameters

## Testing
- `python -m py_compile app/main.py`
- `python - <<'PY'
from urllib.parse import urlencode
CALLBACK_EVENTS_URI = "https://example.com/api/callbacks"
guid = "1234"
caller_id = "+15551234567"
query_parameters = urlencode({"callerId": caller_id})
callback_uri = f"{CALLBACK_EVENTS_URI}/{guid}?{query_parameters}"
print(callback_uri)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a8c39b39d0832db92a35e64e0b28c6